### PR TITLE
Changes in Role model

### DIFF
--- a/lib/registro/repo.ex
+++ b/lib/registro/repo.ex
@@ -1,3 +1,8 @@
 defmodule Registro.Repo do
   use Ecto.Repo, otp_app: :registro
+
+  def exists?(query) do
+    count = Registro.Repo.aggregate(query, :count, :id)
+    count > 0
+  end
 end

--- a/priv/repo/migrations/20170111201412_create_branches_admins.exs
+++ b/priv/repo/migrations/20170111201412_create_branches_admins.exs
@@ -13,7 +13,7 @@ defmodule Registro.Repo.Migrations.CreateBranchesAdmins do
 
   defp super_admins_up do
     alter table(:datasheets) do
-      add :is_super_admin, :boolean
+      add :is_super_admin, :boolean, null: false, default: false
     end
 
     flush

--- a/priv/repo/migrations/20170111201412_create_branches_admins.exs
+++ b/priv/repo/migrations/20170111201412_create_branches_admins.exs
@@ -1,0 +1,65 @@
+defmodule Registro.Repo.Migrations.CreateBranchesAdmins do
+  use Ecto.Migration
+
+  def up do
+    super_admins_up
+    branch_admins_up
+  end
+
+  def down do
+    branch_admins_down
+    super_admins_down
+  end
+
+  defp super_admins_up do
+    alter table(:datasheets) do
+      add :is_super_admin, :boolean
+    end
+
+    flush
+
+    rows = Registro.Repo.query!("SELECT id FROM datasheets WHERE role = 'super_admin'").rows
+
+    Enum.each(rows, fn([datasheet_id]) ->
+      Registro.Repo.query!("UPDATE datasheets SET role = NULL, is_super_admin = TRUE WHERE id = $1", [datasheet_id])
+    end)
+  end
+
+  defp super_admins_down do
+    rows = Registro.Repo.query!("SELECT id FROM datasheets WHERE is_super_admin = TRUE").rows
+
+    Enum.each(rows, fn([datasheet_id]) ->
+      Registro.Repo.query!("UPDATE datasheets SET role = 'super_admin' WHERE id = $1", [datasheet_id])
+    end)
+
+    alter table(:datasheets) do
+      remove :is_super_admin
+    end
+  end
+
+  defp branch_admins_up do
+    create table(:branches_admins) do
+      add :branch_id, references(:branches)
+      add :datasheet_id, references(:datasheets)
+    end
+
+    flush
+
+    rows = Registro.Repo.query!("SELECT id, branch_id FROM datasheets WHERE role = 'branch_admin'").rows
+
+    Enum.each(rows, fn([datasheet_id, branch_id]) ->
+      Registro.Repo.query!("INSERT INTO branches_admins (datasheet_id, branch_id) VALUES ($1, $2)", [datasheet_id, branch_id])
+      Registro.Repo.query!("UPDATE datasheets SET role = NULL, branch_id = NULL WHERE id = $1", [datasheet_id])
+    end)
+  end
+
+  defp branch_admins_down do
+    rows = Registro.Repo.query!("SELECT datasheet_id, branch_id FROM branches_admins").rows
+
+    Enum.each(rows, fn([datasheet_id, branch_id]) ->
+      Registro.Repo.query!("UPDATE datasheets SET role = 'branch_admin', branch_id = $1 WHERE id = $2", [branch_id, datasheet_id])
+    end)
+
+    drop table(:branches_admins)
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,17 +10,22 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-alias Registro.Repo
-alias Registro.Branch
-alias Registro.User
+alias Registro.{
+  Branch,
+  Datasheet,
+  Repo,
+  User
+}
 
 defmodule Seed do
   def run do
-    File.stream!("priv/data/branches.csv")
-    |> Enum.map(&parse_branch_line/1)
-    |> Enum.each(fn [branch_name, address] ->
-      Branch.changeset(%Branch{}, %{name: branch_name, address: address}) |> Repo.insert!
-    end)
+    insert_branches
+
+    branch1 = Repo.get_by!(Branch, name: "Saavedra")
+    branch2 = Repo.get_by!(Branch, name: "Mercedes")
+
+    branch1_admin_email = "#{String.downcase(branch1.name)}_admin@instedd.org"
+    branch2_admin_email = "#{String.downcase(branch2.name)}_admin@instedd.org"
 
     users = [
       %{email: "admin@instedd.org",
@@ -28,21 +33,53 @@ defmodule Seed do
         password_confirmation: "admin",
         datasheet: %{
           name: "Admin",
-          role: "super_admin"
+          is_super_admin: true
         }
        },
-      %{email: "branch@instedd.org",
-        password: "branch",
-        password_confirmation: "branch",
+      %{email: branch1_admin_email,
+        password: "admin",
+        password_confirmation: "admin",
+        datasheet: %{ name: "#{branch1.name} admin" }
+      },
+      %{email: "volunteer1@example.com",
+        password: "volunteer1",
+        password_confirmation: "volunteer1",
         datasheet: %{
-          name: "Branch Employee",
-          role: "branch_admin",
-          branch_id: Repo.get_by!(Branch, name: "Saavedra").id
+          name: "#{branch1.name} volunteer",
+          role: "volunteer",
+          status: "at_start",
+          branch_id: branch1.id
+        }
+      },
+      %{email: branch2_admin_email,
+        password: "admin",
+        password_confirmation: "admin",
+        datasheet: %{ name: "#{branch2.name} admin" }
+      },
+      %{email: "volunteer2@example.com",
+        password: "volunteer2",
+        password_confirmation: "volunteer2",
+        datasheet: %{
+          name: "#{branch2.name} volunteer",
+          role: "volunteer",
+          status: "at_start",
+          branch_id: branch2.id
         }
       }
     ]
 
     Enum.map(users, &insert_user/1)
+
+    mark_as_branch_admin(branch1_admin_email, branch1)
+    mark_as_branch_admin(branch2_admin_email, branch2)
+  end
+
+  def insert_branches do
+    File.stream!("priv/data/branches.csv")
+    |> Enum.map(&parse_branch_line/1)
+    |> Enum.each(fn [branch_name, address] ->
+      Branch.changeset(%Branch{}, %{name: branch_name, address: address}) |> Repo.insert!
+    end)
   end
 
   def parse_branch_line(line) do
@@ -51,9 +88,20 @@ defmodule Seed do
     |> String.split(",")
   end
 
-
   def insert_user(params) do
     User.changeset(:create_with_datasheet, params) |> Repo.insert!
+  end
+
+  def mark_as_branch_admin(email, branch) do
+    import Ecto.Query
+
+    user = User
+         |> preload(:datasheet)
+         |> Repo.get_by!(email: email)
+
+    user.datasheet
+    |> Datasheet.make_admin_changeset([branch])
+    |> Repo.update!
   end
 end
 

--- a/test/controllers/branches_controller_test.exs
+++ b/test/controllers/branches_controller_test.exs
@@ -6,7 +6,7 @@ defmodule Registro.BranchesControllerTest do
 
   test "verifies that user is logged in", %{conn: conn} do
     conn = get conn, "/filiales"
-    assert html_response(conn, 302)
+    assert redirected_to(conn) == "/"
   end
 
   test "does not allow non-admin users", %{conn: conn} do
@@ -16,7 +16,7 @@ defmodule Registro.BranchesControllerTest do
     |> log_in("john@example.com")
     |> get("/filiales")
 
-    assert html_response(conn, 302)
+    assert_unauthorized(conn)
   end
 
   test "does not allow branch_admin", %{conn: conn} do
@@ -26,7 +26,7 @@ defmodule Registro.BranchesControllerTest do
     |> log_in("branch@instedd.org")
     |> get("/filiales")
 
-    assert html_response(conn, 302)
+    assert_unauthorized(conn)
   end
 
   test "displays all branches to super_admin user", %{conn: conn} do

--- a/test/controllers/branches_controller_test.exs
+++ b/test/controllers/branches_controller_test.exs
@@ -1,12 +1,21 @@
 defmodule Registro.BranchesControllerTest do
   use Registro.ConnCase
 
+  import Registro.ModelTestHelpers
   import Registro.ControllerTestHelpers
-
-  alias Registro.Branch
 
   test "verifies that user is logged in", %{conn: conn} do
     conn = get conn, "/filiales"
+    assert html_response(conn, 302)
+  end
+
+  test "does not allow non-admin users", %{conn: conn} do
+    setup_db
+
+    conn = conn
+    |> log_in("john@example.com")
+    |> get("/filiales")
+
     assert html_response(conn, 302)
   end
 
@@ -32,13 +41,12 @@ defmodule Registro.BranchesControllerTest do
   end
 
   def setup_db do
-    create_branch(name: "Branch 1")
-    create_branch(name: "Branch 2")
+    branch1 = create_branch(name: "Branch 1")
+    _branch2 = create_branch(name: "Branch 2")
 
-    branch_id = Repo.get_by!(Branch, name: "Branch 1").id
-
-    create_user(email: "admin@instedd.org", role: "super_admin")
-    create_user(email: "branch@instedd.org", role: "branch_admin", branch_id: branch_id)
+    create_user(email: "john@example.com", role: "volunteer", branch_id: branch1.id)
+    create_super_admin(email: "admin@instedd.org")
+    create_branch_admin(email: "branch@instedd.org", branch: branch1)
   end
 
 end

--- a/test/controllers/branches_controller_test.exs
+++ b/test/controllers/branches_controller_test.exs
@@ -4,40 +4,61 @@ defmodule Registro.BranchesControllerTest do
   import Registro.ModelTestHelpers
   import Registro.ControllerTestHelpers
 
-  test "verifies that user is logged in", %{conn: conn} do
-    conn = get conn, "/filiales"
-    assert redirected_to(conn) == "/"
+  alias Registro.Branch
+
+  describe "listing" do
+    test "verifies that user is logged in", %{conn: conn} do
+      conn = get conn, "/filiales"
+      assert redirected_to(conn) == "/"
+    end
+
+    test "does not allow non-admin users", %{conn: conn} do
+      setup_db
+
+      conn = conn
+      |> log_in("john@example.com")
+      |> get("/filiales")
+
+      assert_unauthorized(conn)
+    end
+
+    test "displays all branches to super_admin user", %{conn: conn} do
+      setup_db
+
+      conn = conn
+      |> log_in("admin@instedd.org")
+      |> get("/filiales")
+
+      assert html_response(conn, 200)
+      assert (Enum.count conn.assigns[:branches]) == 2
+    end
+
+    test "branch admin can only see his administrated branches", %{conn: conn} do
+      setup_db
+
+      conn = conn
+      |> log_in("branch1@instedd.org")
+      |> get("/filiales")
+
+      assert html_response(conn, 200)
+
+      branch_names = conn.assigns[:branches]
+      |> Enum.map(&(&1.name))
+
+      assert branch_names == ["Branch 1"]
+    end
   end
 
-  test "does not allow non-admin users", %{conn: conn} do
+  test "a branch admin cannot access a branch he doesn't administrate", %{conn: conn} do
     setup_db
 
+    branch2 = Repo.get_by!(Branch, name: "Branch 2")
+
     conn = conn
-    |> log_in("john@example.com")
-    |> get("/filiales")
+         |> log_in("branch1@instedd.org")
+         |> get(branches_path(conn, :show, branch2))
 
     assert_unauthorized(conn)
-  end
-
-  test "does not allow branch_admin", %{conn: conn} do
-    setup_db
-
-    conn = conn
-    |> log_in("branch@instedd.org")
-    |> get("/filiales")
-
-    assert_unauthorized(conn)
-  end
-
-  test "displays all branches to super_admin user", %{conn: conn} do
-    setup_db
-
-    conn = conn
-    |> log_in("admin@instedd.org")
-    |> get("/filiales")
-
-    assert html_response(conn, 200)
-    assert (Enum.count conn.assigns[:branches]) == 2
   end
 
   def setup_db do
@@ -46,7 +67,7 @@ defmodule Registro.BranchesControllerTest do
 
     create_user(email: "john@example.com", role: "volunteer", branch_id: branch1.id)
     create_super_admin(email: "admin@instedd.org")
-    create_branch_admin(email: "branch@instedd.org", branch: branch1)
+    create_branch_admin(email: "branch1@instedd.org", branch: branch1)
   end
 
 end

--- a/test/controllers/branches_controller_test.exs
+++ b/test/controllers/branches_controller_test.exs
@@ -16,7 +16,7 @@ defmodule Registro.BranchesControllerTest do
       setup_db
 
       conn = conn
-      |> log_in("john@example.com")
+      |> log_in("mary@example.com")
       |> get("/filiales")
 
       assert_unauthorized(conn)
@@ -37,7 +37,7 @@ defmodule Registro.BranchesControllerTest do
       setup_db
 
       conn = conn
-      |> log_in("branch1@instedd.org")
+      |> log_in("branch_admin1@instedd.org")
       |> get("/filiales")
 
       assert html_response(conn, 200)
@@ -55,19 +55,102 @@ defmodule Registro.BranchesControllerTest do
     branch2 = Repo.get_by!(Branch, name: "Branch 2")
 
     conn = conn
-         |> log_in("branch1@instedd.org")
+         |> log_in("branch_admin1@instedd.org")
          |> get(branches_path(conn, :show, branch2))
 
     assert_unauthorized(conn)
+  end
+
+  describe "update" do
+    test "allows to update a branch's name and address", %{conn: conn} do
+      setup_db
+
+      branch = Repo.get_by!(Branch, name: "Branch 1")
+
+      params = %{ admin_emails: "branch_admin1@instedd.org|branch_admin2@instedd.org",
+                  branch: %{
+                    name: "Updated name",
+                    address: "Updated address" }}
+
+      conn
+      |> log_in("branch_admin1@instedd.org")
+      |> patch(branches_path(conn, :update, branch), params)
+
+      branch = Repo.get!(Branch, branch.id)
+
+      assert branch.name == "Updated name"
+      assert branch.address == "Updated address"
+    end
+
+    test "allows to add branch admins", %{conn: conn} do
+      setup_db
+
+      desired_admins = ["branch_admin1@instedd.org",
+                        "branch_admin2@instedd.org",
+                        "mary@example.com"]
+
+      {_conn, updated_admins} = admins_update(conn, "branch_admin1@instedd.org", "Branch 1", desired_admins)
+
+      assert updated_admins == desired_admins
+    end
+
+    test "allows to remove other admins", %{conn: conn} do
+      setup_db
+
+      {_conn, updated_admins} = admins_update(conn, "branch_admin1@instedd.org", "Branch 1", ["branch_admin1@instedd.org"])
+
+      assert updated_admins == ["branch_admin1@instedd.org"]
+
+      # assert that deleting the association does not delete the user
+      Repo.get_by!(Registro.User, email: "branch_admin2@instedd.org")
+    end
+
+    test "fails if user is trying to remove himself as branch admin", %{conn: conn} do
+      setup_db
+
+      {_conn, updated_admins} = admins_update(conn, "branch_admin1@instedd.org", "Branch 1", ["branch_admin2@instedd.org"])
+
+      assert updated_admins == ["branch_admin1@instedd.org", "branch_admin2@instedd.org"]
+    end
+
+    test "fails if an invalid admin email is provided", %{conn: conn} do
+      setup_db
+
+      {_conn, updated_admins} = admins_update(conn, "branch_admin1@instedd.org", "Branch 1", ["branch_admin1@instedd.org",
+                                                                                              "branch_admin2@instedd.org",
+                                                                                              "unknown@example.com"])
+
+      assert updated_admins == ["branch_admin1@instedd.org", "branch_admin2@instedd.org"]
+    end
+
+    defp admins_update(conn, user_email, branch_name, emails) do
+      branch = Repo.get_by!(Branch, name: branch_name)
+
+      encoded_emails = Enum.join(emails, "|")
+      params = %{ branch: %{ }, admin_emails: encoded_emails}
+
+      conn
+      |> log_in(user_email)
+      |> patch(branches_path(conn, :update, branch), params)
+
+      branch = Repo.get!(Branch, branch.id)
+             |> Repo.preload([admins: :user])
+
+      updated_admins = Enum.map(branch.admins, &(&1.user.email)) |> Enum.sort
+      {conn, updated_admins}
+    end
   end
 
   def setup_db do
     branch1 = create_branch(name: "Branch 1")
     _branch2 = create_branch(name: "Branch 2")
 
-    create_user(email: "john@example.com", role: "volunteer", branch_id: branch1.id)
+    create_user(email: "mary@example.com", role: "volunteer", branch_id: branch1.id)
+
     create_super_admin(email: "admin@instedd.org")
-    create_branch_admin(email: "branch1@instedd.org", branch: branch1)
+
+    create_branch_admin(email: "branch_admin1@instedd.org", branch: branch1)
+    create_branch_admin(email: "branch_admin2@instedd.org", branch: branch1)
   end
 
 end

--- a/test/controllers/home_controller_test.exs
+++ b/test/controllers/home_controller_test.exs
@@ -1,0 +1,41 @@
+defmodule Registro.HomeControllerTest do
+  use Registro.ConnCase
+
+  import Registro.ModelTestHelpers
+  import Registro.ControllerTestHelpers
+
+  test "redirects non-authenticated requests to login page", %{conn: conn} do
+    conn = get(conn, "/")
+
+    assert html_response(conn, 200) =~ "Iniciar sesión"
+  end
+
+  test "redirects colaborators to their profile", %{conn: conn} do
+    branch = create_branch(name: "Branch")
+    volunteer = create_user(email: "volunteer@example.com", role: "volunteer", branch_id: branch.id)
+
+    conn = request_home_as(conn, volunteer)
+
+    assert redirected_to(conn) == "/perfil"
+  end
+
+  test "redirects branch_admin to users listing", %{conn: conn} do
+    branch = create_branch(name: "Branch")
+    branch_admin = create_branch_admin(email: "admin@instedd.org", branch: branch)
+
+    conn = request_home_as(conn, branch_admin)
+
+    assert redirected_to(conn) == "/usuarios"
+  end
+
+  test "redirects super_admin to usersl listing", %{conn: conn} do
+    super_admin = create_super_admin(email: "admin@instedd.org")
+    conn = request_home_as(conn, super_admin)
+
+    assert redirected_to(conn) == "/usuarios"
+  end
+
+  defp request_home_as(conn, user) do
+    conn |> log_in(user) |> get("/")
+  end
+end

--- a/test/controllers/invitations_controller_test.exs
+++ b/test/controllers/invitations_controller_test.exs
@@ -6,7 +6,17 @@ defmodule Registro.InvitationsControllerTest do
 
   alias Registro.{Invitation, Datasheet, User}
 
-  describe "sending invitatioins" do
+  test "renders invitation form", %{conn: conn} do
+    admin = create_super_admin(email: "admin@instedd.org")
+
+    conn = conn
+    |> log_in(admin)
+    |> get("/usuarios/alta")
+
+    assert html_response(conn, 200)
+  end
+
+  describe "sending invitations" do
     test "invitation creation with associated datasheet", %{conn: conn} do
       branch = create_branch(name: "Branch")
       admin = create_super_admin(email: "admin@instedd.org")

--- a/test/controllers/invitations_controller_test.exs
+++ b/test/controllers/invitations_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule Registro.InvitationsControllerTest do
   use Registro.ConnCase
 
+  import Registro.ModelTestHelpers
   import Registro.ControllerTestHelpers
 
   alias Registro.{Invitation, Datasheet, User}
@@ -8,7 +9,7 @@ defmodule Registro.InvitationsControllerTest do
   describe "sending invitatioins" do
     test "invitation creation with associated datasheet", %{conn: conn} do
       branch = create_branch(name: "Branch")
-      admin = create_user(email: "admin@instedd.org", role: "super_admin")
+      admin = create_super_admin(email: "admin@instedd.org")
 
       params = invitation_params(branch.id)
 
@@ -23,7 +24,7 @@ defmodule Registro.InvitationsControllerTest do
 
     test "branch admin can send invitations for the same branch", %{conn: conn} do
       branch = create_branch(name: "Branch")
-      branch_admin = create_user(email: "branch1@instedd.org", role: "branch_admin", branch_id: branch.id)
+      branch_admin = create_branch_admin(email: "branch1@instedd.org", branch: branch)
 
       params = invitation_params(branch.id)
 
@@ -40,7 +41,7 @@ defmodule Registro.InvitationsControllerTest do
       branch1 = create_branch(name: "Branch 1")
       branch2 = create_branch(name: "Branch 2")
 
-      branch1_admin = create_user(email: "branch1@instedd.org", role: "branch_admin", branch_id: branch1.id)
+      branch1_admin = create_branch_admin(email: "branch1@instedd.org", branch: branch1)
 
       params = invitation_params(branch2.id)
 

--- a/test/controllers/users_controller_test.exs
+++ b/test/controllers/users_controller_test.exs
@@ -55,7 +55,54 @@ defmodule Registro.UsersControllerTest do
     end
   end
 
-  describe "approval" do
+  describe "update" do
+    test "a super_admin can update a user's branch", %{conn: conn} do
+      setup_db
+
+      volunteer = get_user_by_email("volunteer1@example.com")
+
+      assert volunteer.datasheet.role == "volunteer"
+      assert volunteer.datasheet.branch.name == "Branch 1"
+
+      update_params = %{
+        branch_name: "Branch 2",
+        user: %{
+          datasheet: %{ id: volunteer.datasheet.id, role: "associate" }
+        }}
+
+      conn
+      |> log_in("admin@instedd.org")
+      |> patch(users_path(Registro.Endpoint, :update, volunteer), update_params)
+
+      volunteer = get_user_by_email("volunteer1@example.com")
+
+      assert volunteer.datasheet.role == "associate"
+      assert volunteer.datasheet.branch.name == "Branch 2"
+    end
+
+    test "a branch admin cannot update a user's branch", %{conn: conn} do
+      setup_db
+
+      volunteer = get_user_by_email("volunteer1@example.com")
+
+      assert volunteer.datasheet.role == "volunteer"
+      assert volunteer.datasheet.branch.name == "Branch 1"
+
+      update_params = %{
+        branch_name: "Branch 2",
+        user: %{
+          datasheet: %{ id: volunteer.datasheet.id, role: "associate" }
+        }}
+
+      conn
+      |> log_in("branch_admin1@instedd.org")
+      |> patch(users_path(Registro.Endpoint, :update, volunteer), update_params)
+
+      updated_volunteer = get_user_by_email("volunteer1@example.com")
+
+      assert volunteer == updated_volunteer
+    end
+
     test "an super_admin is allowed to change the status of any volunteer", %{conn: conn} do
       setup_db
 

--- a/test/models/datasheet_test.exs
+++ b/test/models/datasheet_test.exs
@@ -66,9 +66,7 @@ defmodule Registro.DatasheetTest do
     datasheet = create_datasheet(%{"name" => "John", "role" => nil, "branch_id" => nil, "status" => nil})
 
     datasheet = datasheet
-    |> Repo.preload(:admin_branches)
-    |> change
-    |> put_assoc(:admin_branches, [branch1, branch2])
+    |> Datasheet.make_admin_changeset([branch1, branch2])
     |> Repo.update!
 
     assert Enum.count(datasheet.admin_branches) == 2

--- a/test/models/datasheet_test.exs
+++ b/test/models/datasheet_test.exs
@@ -1,14 +1,16 @@
 defmodule Registro.DatasheetTest do
   use Registro.ModelCase
 
-  alias Registro.Branch
+  import Registro.ModelTestHelpers
+
   alias Registro.Datasheet
 
   test "a datasheet can be created without association to a user" do
     cs = Datasheet.changeset(%Datasheet{name: "John"},
-      %{role: "super_admin",
+      %{role: nil,
         branch_id: nil,
-        status: "approved"
+        status: nil,
+        is_super_admin: true
       })
 
     assert cs.valid?
@@ -18,10 +20,29 @@ defmodule Registro.DatasheetTest do
     cs = Datasheet.changeset(%Datasheet{name: "John"},
       %{role: "volunteer",
         branch_id: nil,
-        status: "approved"
+        status: "approved",
+        is_super_admin: false
     })
 
     assert invalid_fields(cs) == [:branch_id]
+  end
+
+  test "role can not have arbitrary values" do
+    branch = create_branch(name: "Branch")
+
+    changeset = fn(role) ->
+      Datasheet.changeset(%Datasheet{},
+        %{name: "John",
+          role: role,
+          branch_id: branch.id,
+          status: "approved",
+          is_super_admin: false
+      })
+    end
+
+    assert changeset.("volunteer").valid?
+    assert changeset.("associate").valid?
+    refute changeset.("something_else").valid?
   end
 
   test "a volunteer cannot have empty status" do
@@ -30,24 +51,36 @@ defmodule Registro.DatasheetTest do
     cs = Datasheet.changeset(%Datasheet{name: "John"},
       %{role: "volunteer",
         branch_id: branch.id,
-        status: nil
+        status: nil,
+        is_super_admin: false
       })
 
     assert invalid_fields(cs) == [:status]
+  end
+
+  test "a datasheet can be assigned as admin to multiple branches" do
+    branch1 = create_branch(name: "Branch 1")
+    branch2 = create_branch(name: "Branch 2")
+    branch3 = create_branch(name: "Branch 3")
+
+    datasheet = create_datasheet(%{"name" => "John", "role" => nil, "branch_id" => nil, "status" => nil})
+
+    datasheet = datasheet
+    |> Repo.preload(:admin_branches)
+    |> change
+    |> put_assoc(:admin_branches, [branch1, branch2])
+    |> Repo.update!
+
+    assert Enum.count(datasheet.admin_branches) == 2
+
+    assert Datasheet.is_admin_of?(datasheet, branch1)
+    assert Datasheet.is_admin_of?(datasheet, branch2)
+    refute Datasheet.is_admin_of?(datasheet, branch3)
   end
 
   def invalid_fields(changeset) do
     changeset.errors
     |> Keyword.keys
     |> Enum.uniq
-  end
-
-  def create_branch(name: name) do
-    changeset = Branch.changeset(%Branch{}, %{
-          name: name,
-          address: "generated"
-    })
-
-    Repo.insert! changeset
   end
 end

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -8,9 +8,10 @@ defmodule Registro.UserTest do
   test "a user can be created with a datasheet" do
     params = Map.put(@valid_user_attrs, :datasheet, %{
       name: "John",
-      role: "super_admin",
+      role: nil,
       branch_id: nil,
-      status: "approved"
+      status: nil,
+      is_super_admin: true
     })
 
     changeset = User.changeset(:create_with_datasheet, params)
@@ -20,17 +21,19 @@ defmodule Registro.UserTest do
     %User{ datasheet: datasheet } = Registro.Repo.insert!(changeset)
 
     assert datasheet.name == "John"
-    assert datasheet.role == "super_admin"
+    assert datasheet.role == nil
     assert datasheet.branch_id == nil
-    assert datasheet.status == "approved"
+    assert datasheet.status == nil
+    assert datasheet.is_super_admin
   end
 
   test "a user cannot be created with an invalid datasheet" do
     params = Map.put(@valid_user_attrs, :datasheet, %{
           name: nil,
-          role: "super_admin",
+          role: nil,
           branch_id: nil,
-          status: "approved"
+          status: nil,
+          is_super_admin: true
     })
 
     refute User.changeset(:create_with_datasheet, params).valid?

--- a/test/models/user_test.exs
+++ b/test/models/user_test.exs
@@ -1,6 +1,8 @@
 defmodule Registro.UserTest do
   use Registro.ModelCase
 
+  import Registro.ModelTestHelpers
+
   alias Registro.User
 
   @valid_user_attrs %{email: "john@example.com", password: "fooo", password_confirmation: "fooo"}
@@ -37,5 +39,22 @@ defmodule Registro.UserTest do
     })
 
     refute User.changeset(:create_with_datasheet, params).valid?
+  end
+
+  test "cannot mark as colaborator of a branch without setting role" do
+    branch1 = create_branch(name: "Branch 1")
+    branch2 = create_branch(name: "Branch 2")
+
+    user = create_branch_admin(email: "john@example.com", branch: branch1)
+
+    update_params = %{datasheet: %{
+                         id: user.datasheet.id,
+                         role: nil,
+                         branch_id: branch2.id
+                      }}
+
+    cs = User.changeset(user, :update, update_params)
+
+    refute cs.valid?
   end
 end

--- a/test/support/controller_test_helpers.ex
+++ b/test/support/controller_test_helpers.ex
@@ -1,7 +1,7 @@
 defmodule Registro.ControllerTestHelpers do
 
   alias Registro.Repo
-  alias Registro.{Branch, User, Role}
+  alias Registro.User
 
   def log_in(conn, %User{} = user) do
     Plug.Conn.assign(conn, :current_user, user)
@@ -12,30 +12,4 @@ defmodule Registro.ControllerTestHelpers do
     log_in(conn, user)
   end
 
-  def create_user(email: email, role: role) do
-    create_user(email: email, role: role, branch_id: nil)
-  end
-
-  def create_user(email: email, role: role, branch_id: branch_id) do
-    changeset = User.changeset(:create_with_datasheet, %{
-          email: email,
-          password: "generated",
-          password_confirmation: "generated",
-          datasheet: %{
-            name: "generated #{role}",
-            role: role,
-            branch_id: branch_id,
-            status: (if Role.is_admin?(role), do: nil, else: "at_start")
-          }
-    })
-    Repo.insert! changeset
-  end
-
-  def create_branch(name: name) do
-    changeset = Branch.changeset(%Branch{}, %{
-          name: name,
-          address: "generated"
-    })
-    Repo.insert! changeset
-  end
 end

--- a/test/support/controller_test_helpers.ex
+++ b/test/support/controller_test_helpers.ex
@@ -12,4 +12,10 @@ defmodule Registro.ControllerTestHelpers do
     log_in(conn, user)
   end
 
+  defmacro assert_unauthorized(conn) do
+    quote do
+      assert redirected_to(unquote(conn)) == "/"
+      assert get_flash(unquote(conn), :info) == "Página no accesible"
+    end
+  end
 end

--- a/test/support/model_test_helpers.ex
+++ b/test/support/model_test_helpers.ex
@@ -34,9 +34,7 @@ defmodule Registro.ModelTestHelpers do
     user = Repo.insert! changeset
 
     user.datasheet
-    |> Repo.preload(:admin_branches)
-    |> Ecto.Changeset.change
-    |> Ecto.Changeset.put_assoc(:admin_branches, branches)
+    |> Datasheet.make_admin_changeset(branches)
     |> Repo.update!
 
     user

--- a/test/support/model_test_helpers.ex
+++ b/test/support/model_test_helpers.ex
@@ -12,7 +12,7 @@ defmodule Registro.ModelTestHelpers do
           email: email,
           password: "generated", password_confirmation: "generated",
           datasheet: %{
-            name: "generated #{role}",
+            name: name(email),
             role: role,
             branch_id: branch_id,
             status: "at_start"
@@ -28,7 +28,7 @@ defmodule Registro.ModelTestHelpers do
           email: email,
           password: "generated", password_confirmation: "generated",
           datasheet: %{
-            name: "generated branch admin",
+            name: name(email),
             role: nil, branch_id: nil, status: nil}})
 
     user = Repo.insert! changeset
@@ -47,7 +47,7 @@ defmodule Registro.ModelTestHelpers do
           email: email,
           password: "generated", password_confirmation: "generated",
           datasheet: %{
-            name: "generated super_admin",
+            name: name(email),
             role: nil,
             branch_id: nil,
             status: nil,
@@ -68,5 +68,9 @@ defmodule Registro.ModelTestHelpers do
           address: "generated"
     })
     Repo.insert! changeset
+  end
+
+  defp name(email) do
+    String.replace(email, ~r/@.*/, "")
   end
 end

--- a/test/support/model_test_helpers.ex
+++ b/test/support/model_test_helpers.ex
@@ -1,0 +1,72 @@
+defmodule Registro.ModelTestHelpers do
+
+  alias Registro.Repo
+  alias Registro.{Branch, User, Datasheet}
+
+  def create_user(email: email, role: role) do
+    create_user(email: email, role: role, branch_id: nil)
+  end
+
+  def create_user(email: email, role: role, branch_id: branch_id) do
+    changeset = User.changeset(:create_with_datasheet, %{
+          email: email,
+          password: "generated", password_confirmation: "generated",
+          datasheet: %{
+            name: "generated #{role}",
+            role: role,
+            branch_id: branch_id,
+            status: "at_start"
+          }})
+    Repo.insert! changeset
+  end
+
+  def create_branch_admin(email: email, branch: branch),
+    do: create_branch_admin(email: email, branches: [branch])
+
+  def create_branch_admin(email: email, branches: branches) do
+    changeset = User.changeset(:create_with_datasheet, %{
+          email: email,
+          password: "generated", password_confirmation: "generated",
+          datasheet: %{
+            name: "generated branch admin",
+            role: nil, branch_id: nil, status: nil}})
+
+    user = Repo.insert! changeset
+
+    user.datasheet
+    |> Repo.preload(:admin_branches)
+    |> Ecto.Changeset.change
+    |> Ecto.Changeset.put_assoc(:admin_branches, branches)
+    |> Repo.update!
+
+    user
+  end
+
+  def create_super_admin(email: email) do
+    changeset = User.changeset(:create_with_datasheet, %{
+          email: email,
+          password: "generated", password_confirmation: "generated",
+          datasheet: %{
+            name: "generated super_admin",
+            role: nil,
+            branch_id: nil,
+            status: nil,
+            is_super_admin: true
+          }})
+
+    Repo.insert! changeset
+  end
+
+  def create_datasheet(params) do
+    Datasheet.changeset(%Datasheet{}, params)
+    |> Repo.insert!
+  end
+
+  def create_branch(name: name) do
+    changeset = Branch.changeset(%Branch{}, %{
+          name: name,
+          address: "generated"
+    })
+    Repo.insert! changeset
+  end
+end

--- a/web/controllers/branches_controller.ex
+++ b/web/controllers/branches_controller.ex
@@ -5,7 +5,6 @@ defmodule Registro.BranchesController do
   alias Registro.Repo
   alias Registro.Branch
   alias Registro.Pagination
-  alias Registro.Role
 
   plug Registro.Authorization, check: &BranchesController.authorize_request/2
 

--- a/web/controllers/branches_controller.ex
+++ b/web/controllers/branches_controller.ex
@@ -2,7 +2,7 @@ defmodule Registro.BranchesController do
   use Registro.Web, :controller
 
   alias __MODULE__
-  alias Registro.{Repo, Branch, Pagination, Datasheet, User}
+  alias Registro.{Repo, Branch, Pagination, Datasheet, User, Invitation}
 
   plug Registro.Authorization, [ check: &BranchesController.authorize_listing/2 ] when action in [:index]
   plug Registro.Authorization, [ check: &BranchesController.authorize_detail/2 ] when action in [:show, :update]
@@ -45,32 +45,60 @@ defmodule Registro.BranchesController do
   end
 
   def show(conn, params) do
-    branch = Repo.one(from u in Branch, where: u.id == ^params["id"], preload: [admins: :user])
+    branch = Repo.one(from u in Branch, where: u.id == ^params["id"], preload: [admins: [:user, :invitation]])
+
+    admin_emails = branch.admins |> Enum.map(&Datasheet.email/1)
+
     changeset = Branch.changeset(branch)
 
     conn
-    |> render("show.html", changeset: changeset, branch: branch)
+    |> render("show.html", changeset: changeset, branch: branch, admin_emails: admin_emails)
   end
 
-  def update(conn, %{"branch" => branch_params, "admin_emails" => encoded_admin_emails} = params) do
+  def update(conn, %{"branch" => branch_params, "admin_emails" => encoded_emails} = params) do
     branch = Repo.one!(from b in Branch, where: b.id == ^params["id"], preload: [admins: :user])
 
-    admin_emails = String.split(encoded_admin_emails, "|")
+    emails = String.split(encoded_emails, "|")
+           |> Enum.filter(&(String.match?(&1, ~r/@/)))
+
+    preexisting_datasheets = Repo.all(from d in Datasheet,
+      left_join: u in assoc(d, :user),
+      left_join: i in assoc(d, :invitation),
+      where: (u.email in ^emails) or (i.email in ^emails),
+      preload: [:user, :invitation]
+    )
+
+    preexisting_emails = preexisting_datasheets
+                       |> Enum.map(&Datasheet.email/1)
+
+    new_datasheets = emails
+                    |> Enum.filter(fn(email) -> !Enum.member?(preexisting_emails, email) end)
+                    |> Enum.map(&BranchesController.invite!/1)
+
+    admin_datasheets = preexisting_datasheets ++ new_datasheets
 
     changeset = branch
               |> Branch.changeset(branch_params)
-              |> Branch.update_admins(admin_emails)
-              |> validate_admin_not_removing_himself(Coherence.current_user(conn).email)
+              |> Branch.update_admins(admin_datasheets)
+              |> validate_admin_not_removing_himself(Coherence.current_user(conn))
 
     case Repo.update(changeset) do
       {:ok, _branch} ->
+        msg = case new_datasheets do
+                [] ->
+                  "Los cambios en la filial fueron efectuados."
+                [d] ->
+                  "Se envió una invitación a #{Datasheet.email(d)} para ser administrador de la filial."
+                [_|_] ->
+                  "Se enviaron #{Enum.count(new_datasheets)} invitaciones para los nuevos administradores de la filial."
+              end
         conn
-        |> put_flash(:info, "Los cambios en la filial fueron efectuados.")
+        |> put_flash(:info, msg)
         |> redirect(to: branches_path(conn, :show, branch))
       {:error, changeset} ->
         conn
         |> put_flash(:error, "Error al actualizar los datos de la filial")
-        |> render("show.html", changeset: changeset, branch: branch)
+        |> render("show.html", changeset: changeset, branch: branch, admin_emails: emails)
     end
   end
 
@@ -102,15 +130,37 @@ defmodule Registro.BranchesController do
     datasheet.is_super_admin || Datasheet.is_admin_of?(datasheet, branch_id)
   end
 
-  defp validate_admin_not_removing_himself(changeset, current_email) do
-    admin_emails = Ecto.Changeset.get_field(changeset, :admins)
-                |> Enum.map(&(&1.user.email))
-
-    if Enum.member?(admin_emails, current_email) do
+  defp validate_admin_not_removing_himself(changeset, current_user) do
+    if current_user.datasheet.is_super_admin do
       changeset
     else
-      msg = "No es posible removerse a uno mismo como administrador de la filial"
-      changeset |> Ecto.Changeset.add_error(:datasheet, msg)
+      admin_emails = Ecto.Changeset.get_field(changeset, :admins) |> Enum.map(&Datasheet.email/1)
+
+      if Enum.member?(admin_emails, current_user.email) do
+        changeset
+      else
+        msg = "No es posible removerse a uno mismo como administrador de la filial"
+        changeset |> Ecto.Changeset.add_error(:datasheet, msg)
+      end
     end
+  end
+
+  def invite!(email) do
+    # TODO: We are currently validating that datasheets have a valid name, but when sending invitations
+    # for branch admins we need to have a datasheet to grant permissions to, even if we only have the email.
+    invitation_params = %{ "name" => "Completar",
+                           "email" => email,
+                           "datasheet" => %{
+                             "name" => "Completar"
+                           }}
+
+    invitation_cs = Invitation.changeset(%Invitation{}, invitation_params)
+    |> Invitation.generate_token
+
+    invitation = Repo.insert!(invitation_cs)
+
+    Coherence.ControllerHelpers.send_user_email :invitation, invitation, Invitation.accept_url(invitation)
+
+    invitation.datasheet
   end
 end

--- a/web/controllers/branches_controller.ex
+++ b/web/controllers/branches_controller.ex
@@ -2,28 +2,38 @@ defmodule Registro.BranchesController do
   use Registro.Web, :controller
 
   alias __MODULE__
-  alias Registro.Repo
-  alias Registro.Branch
-  alias Registro.Pagination
+  alias Registro.{Repo, Branch, Pagination, Datasheet, User}
 
-  plug Registro.Authorization, check: &BranchesController.authorize_request/2
+  plug Registro.Authorization, [ check: &BranchesController.authorize_listing/2 ] when action in [:index]
+  plug Registro.Authorization, [ check: &BranchesController.authorize_detail/2 ] when action in [:show, :update]
 
   def index(conn, params) do
     import Ecto.Query
 
+    datasheet = Coherence.current_user(conn).datasheet
+
+    query = if datasheet.is_super_admin do
+              from b in Branch
+            else
+              branch_ids = datasheet.admin_branches |> Enum.map(&(&1.id))
+
+              from b in Branch, where: b.id in ^branch_ids
+            end
+
+    query = from b in query, order_by: :name
+
     page = Pagination.requested_page(params)
-    total_count = Repo.aggregate(Branch, :count, :id)
+    total_count = Repo.aggregate(query, :count, :id)
     page_count = Pagination.page_count(total_count)
+    branches = Pagination.all(query, page_number: page)
 
     {template, conn} = case params["raw"] do
-                       nil ->
-                         { "index.html", conn }
+                         nil ->
+                           { "index.html", conn }
 
-                       _   ->
-                         { "listing.html", put_layout(conn, false) }
-                     end
-
-    branches = Pagination.all((from b in Branch, order_by: :name), page_number: page)
+                         _   ->
+                           { "listing.html", put_layout(conn, false) }
+                       end
 
     render(conn, template,
       branches: branches,
@@ -73,7 +83,13 @@ defmodule Registro.BranchesController do
     end
   end
 
-  def authorize_request(_conn, current_user) do
-    current_user.datasheet.is_super_admin
+  def authorize_listing(_conn, %User{datasheet: datasheet}) do
+    Datasheet.is_admin?(datasheet)
+  end
+
+  def authorize_detail(conn, %User{datasheet: datasheet}) do
+    branch_id = String.to_integer(conn.params["id"])
+
+    datasheet.is_super_admin || Datasheet.is_admin_of?(datasheet, branch_id)
   end
 end

--- a/web/controllers/branches_controller.ex
+++ b/web/controllers/branches_controller.ex
@@ -159,7 +159,10 @@ defmodule Registro.BranchesController do
 
     invitation = Repo.insert!(invitation_cs)
 
-    Coherence.ControllerHelpers.send_user_email :invitation, invitation, Invitation.accept_url(invitation)
+    spawn fn ->
+      # TODO: use a mailing queue and provide a mechanism to resend failed invitations
+      Coherence.ControllerHelpers.send_user_email :invitation, invitation, Invitation.accept_url(invitation)
+    end
 
     invitation.datasheet
   end

--- a/web/controllers/branches_controller.ex
+++ b/web/controllers/branches_controller.ex
@@ -1,12 +1,13 @@
 defmodule Registro.BranchesController do
   use Registro.Web, :controller
 
+  alias __MODULE__
   alias Registro.Repo
   alias Registro.Branch
   alias Registro.Pagination
   alias Registro.Role
 
-  plug Registro.Authorization, check_role: &Role.is_super_admin?/1
+  plug Registro.Authorization, check: &BranchesController.authorize_request/2
 
   def index(conn, params) do
     import Ecto.Query
@@ -73,14 +74,7 @@ defmodule Registro.BranchesController do
     end
   end
 
-  def authorize_request(role) do
-    case role do
-      "super_admin" ->
-        true
-      "branch_admin" ->
-        true
-      _ ->
-        false
-    end
+  def authorize_request(_conn, current_user) do
+    current_user.datasheet.is_super_admin
   end
 end

--- a/web/controllers/coherence/invitation_controller.ex
+++ b/web/controllers/coherence/invitation_controller.ex
@@ -59,12 +59,10 @@ defmodule Registro.Coherence.InvitationController do
 
     case repo.one from u in user_schema, where: u.email == ^email do
       nil ->
-        token = random_string 48
-        url = router_helpers.invitation_url(conn, :edit, token)
-        cs = put_change(cs, :token, token)
+        cs = Invitation.generate_token(cs)
         case Config.repo.insert cs do
           {:ok, invitation} ->
-            send_user_email :invitation, invitation, url
+            send_user_email :invitation, invitation, Invitation.accept_url(invitation)
             Registro.UserAuditLogEntry.add(invitation.datasheet_id, Coherence.current_user(conn), :invite_send)
 
             conn

--- a/web/controllers/coherence/invitation_controller.ex
+++ b/web/controllers/coherence/invitation_controller.ex
@@ -185,20 +185,17 @@ defmodule Registro.Coherence.InvitationController do
     is_protected_action = Enum.member?([:new, :create, :resend], action)
 
     if is_protected_action do
-      %Datasheet{ role: role, branch_id: branch_id } = current_user.datasheet
+      datasheet = current_user.datasheet
 
-      case {action, role} do
-        {_, "super_admin"} ->
-          true
-
-        {:new, "branch_admin"} ->
-          true
-
-        {:create, "branch_admin"} ->
-          branch_id == target_branch_id(conn.params)
-
-        {:resend, "branch_admin"} ->
-          branch_id == target_branch_id(conn.params)
+      cond do
+        datasheet.is_super_admin -> true
+        Datasheet.is_branch_admin?(datasheet) ->
+          case action do
+            :new ->
+              true
+            _ ->
+              Datasheet.is_admin_of?(datasheet, target_branch_id(conn.params))
+          end
       end
     else
       true

--- a/web/controllers/home_controller.ex
+++ b/web/controllers/home_controller.ex
@@ -8,7 +8,7 @@ defmodule Registro.HomeController do
       _ ->
         user = conn.assigns[:current_user]
 
-        if Registro.Role.is_admin?(user.datasheet.role) do
+        if Registro.Datasheet.is_admin?(user.datasheet) do
           redirect(conn, to: users_path(conn, :index))
         else
           redirect(conn, to: users_path(conn, :profile))

--- a/web/models/branch.ex
+++ b/web/models/branch.ex
@@ -3,11 +3,15 @@ defmodule Registro.Branch do
 
   @derive {Poison.Encoder, only: [:name, :id]}
 
+  alias Registro.{Datasheet, Repo}
+
   schema "branches" do
     field :name, :string
     field :address, :string
 
-    many_to_many :admins, Registro.Datasheet, join_through: "branches_admins"
+    many_to_many :admins, Registro.Datasheet,
+      join_through: "branches_admins",
+      on_replace: :delete # allow to delete admins by updating the branch
 
     timestamps
   end
@@ -17,6 +21,18 @@ defmodule Registro.Branch do
     |> cast(params, [:name, :address])
     |> validate_required([:name, :address])
     |> unique_constraint(:name)
+  end
+
+  def update_admins(changeset, admin_emails) do
+    admin_datasheets = Repo.all(from d in Datasheet, left_join: u in assoc(d, :user), where: u.email in ^admin_emails, preload: :user)
+
+    changeset = Ecto.Changeset.put_assoc(changeset, :admins, admin_datasheets)
+
+    if Enum.count(admin_emails) == Enum.count(admin_datasheets) do
+      changeset
+    else
+      changeset |> Ecto.Changeset.add_error(:datasheet, "Email de administrador inválido")
+    end
   end
 
   def all do

--- a/web/models/branch.ex
+++ b/web/models/branch.ex
@@ -3,8 +3,6 @@ defmodule Registro.Branch do
 
   @derive {Poison.Encoder, only: [:name, :id]}
 
-  alias Registro.{Datasheet, Repo}
-
   schema "branches" do
     field :name, :string
     field :address, :string
@@ -23,16 +21,8 @@ defmodule Registro.Branch do
     |> unique_constraint(:name)
   end
 
-  def update_admins(changeset, admin_emails) do
-    admin_datasheets = Repo.all(from d in Datasheet, left_join: u in assoc(d, :user), where: u.email in ^admin_emails, preload: :user)
-
-    changeset = Ecto.Changeset.put_assoc(changeset, :admins, admin_datasheets)
-
-    if Enum.count(admin_emails) == Enum.count(admin_datasheets) do
-      changeset
-    else
-      changeset |> Ecto.Changeset.add_error(:datasheet, "Email de administrador inválido")
-    end
+  def update_admins(changeset, admin_datasheets) do
+    Ecto.Changeset.put_assoc(changeset, :admins, admin_datasheets)
   end
 
   def all do

--- a/web/models/branch.ex
+++ b/web/models/branch.ex
@@ -6,6 +6,9 @@ defmodule Registro.Branch do
   schema "branches" do
     field :name, :string
     field :address, :string
+
+    many_to_many :admins, Registro.Datasheet, join_through: "branches_admins"
+
     timestamps
   end
 

--- a/web/models/coherence/user.ex
+++ b/web/models/coherence/user.ex
@@ -64,7 +64,7 @@ defmodule Registro.User do
   end
 
   def preload_datasheet(user) do
-    Repo.preload(user, [datasheet: [:branch]])
+    Repo.preload(user, [datasheet: [:branch, :admin_branches]])
   end
 
   def query_with_datasheet do
@@ -73,6 +73,6 @@ defmodule Registro.User do
 
   def query_with_datasheet(q) do
     import Ecto.Query
-    from u in q, preload: [datasheet: [:branch]]
+    from u in q, preload: [datasheet: [:branch, :admin_branches]]
   end
 end

--- a/web/models/datasheet.ex
+++ b/web/models/datasheet.ex
@@ -25,7 +25,7 @@ defmodule Registro.Datasheet do
     |> cast(params, [:name, :status, :branch_id, :role, :is_super_admin])
     |> cast_assoc(:admin_branches, required: false)
     |> validate_required([:name])
-    |> validate_volunteer_fields
+    |> validate_colaboration
   end
 
   def make_admin_changeset(datasheet, branches) do
@@ -93,16 +93,20 @@ defmodule Registro.Datasheet do
     |> Enum.any?(&(&1.id == branch_id))
   end
 
-  defp validate_volunteer_fields(changeset) do
+  defp validate_colaboration(changeset) do
+    # if a user participates as colaborator of branch, these three fields must be present
     role = Ecto.Changeset.get_field(changeset, :role)
+    branch_id = Ecto.Changeset.get_field(changeset, :branch_id)
+    status = Ecto.Changeset.get_field(changeset, :status)
 
-    if role != nil do
-      changeset
-      |> validate_role
-      |> validate_required([:branch_id, :status])
-      |> validate_status
-    else
-      changeset
+    case {role, branch_id, status} do
+      {nil, nil, nil} ->
+        changeset
+      _ ->
+        changeset
+        |> validate_required([:role, :branch_id, :status])
+        |> validate_role
+        |> validate_status
     end
   end
 

--- a/web/models/datasheet.ex
+++ b/web/models/datasheet.ex
@@ -2,7 +2,9 @@ defmodule Registro.Datasheet do
   use Registro.Web, :model
 
   alias __MODULE__
+  alias Registro.User
   alias Registro.Branch
+  alias Registro.Invitation
 
   schema "datasheets" do
     field :name, :string
@@ -11,6 +13,7 @@ defmodule Registro.Datasheet do
     field :is_super_admin, :boolean
 
     has_one :user, Registro.User
+    has_one :invitation, Registro.Invitation
 
     # the branch to which the person acts as a volunteer or associate
     belongs_to :branch, Registro.Branch
@@ -92,6 +95,18 @@ defmodule Registro.Datasheet do
 
     datasheet.admin_branches
     |> Enum.any?(&(&1.id == branch_id))
+  end
+
+  def email(datasheet) do
+    datasheet = Registro.Repo.preload(datasheet, [:user, :invitation])
+
+    case datasheet do
+      %Datasheet{ user: %User{email: email} } ->
+        email
+
+      %Datasheet{ invitation: %Invitation{ email: email } } ->
+        email
+    end
   end
 
   defp validate_colaboration(changeset) do

--- a/web/models/datasheet.ex
+++ b/web/models/datasheet.ex
@@ -56,6 +56,7 @@ defmodule Registro.Datasheet do
       Datasheet.is_branch_admin?(datasheet) -> "Administrador de Filial"
       Datasheet.is_volunteer?(datasheet) -> "Voluntario"
       Datasheet.is_associate?(datasheet) -> "Asociado"
+      true -> ""
     end
   end
 

--- a/web/models/datasheet.ex
+++ b/web/models/datasheet.ex
@@ -48,7 +48,7 @@ defmodule Registro.Datasheet do
       datasheet.is_super_admin -> "Administrador de Sede Central"
       Datasheet.is_branch_admin?(datasheet) -> "Administrador de Filial"
       Datasheet.is_volunteer?(datasheet) -> "Voluntario"
-      Datasheet.is_associate(datasheet) -> "Asociado"
+      Datasheet.is_associate?(datasheet) -> "Asociado"
     end
   end
 
@@ -56,8 +56,12 @@ defmodule Registro.Datasheet do
     datasheet.role == "volunteer"
   end
 
-  def is_associate(datasheet) do
+  def is_associate?(datasheet) do
     datasheet.role == "associate"
+  end
+
+  def is_colaborator?(datasheet) do
+    is_volunteer?(datasheet) or is_associate?(datasheet)
   end
 
   def is_admin?(datasheet) do

--- a/web/models/datasheet.ex
+++ b/web/models/datasheet.ex
@@ -2,7 +2,7 @@ defmodule Registro.Datasheet do
   use Registro.Web, :model
 
   alias __MODULE__
-  alias Registro.{Branch, Role}
+  alias Registro.Branch
 
   schema "datasheets" do
     field :name, :string
@@ -101,10 +101,11 @@ defmodule Registro.Datasheet do
 
   defp validate_role(changeset) do
     role = Ecto.Changeset.get_field(changeset, :role)
-    if !Role.is_valid?(role) do
-      changeset |> Ecto.Changeset.add_error(:role, "is invalid")
-    else
+
+    if role == "volunteer" || role == "associate" do
       changeset
+    else
+      changeset |> Ecto.Changeset.add_error(:role, "is invalid")
     end
   end
 

--- a/web/models/datasheet.ex
+++ b/web/models/datasheet.ex
@@ -8,8 +8,13 @@ defmodule Registro.Datasheet do
     field :status, :string
     field :role, :string
 
-    belongs_to :branch, Registro.Branch
     has_one :user, Registro.User
+
+    # the branch to which the person acts as a volunteer or associate
+    belongs_to :branch, Registro.Branch
+
+    # the branches in which the person acts as an administrator
+    many_to_many :admin_branches, Registro.Branch, join_through: "branches_admins"
   end
 
 

--- a/web/models/datasheet.ex
+++ b/web/models/datasheet.ex
@@ -28,6 +28,13 @@ defmodule Registro.Datasheet do
     |> validate_volunteer_fields
   end
 
+  def make_admin_changeset(datasheet, branches) do
+    datasheet
+    |> Registro.Repo.preload(:admin_branches)
+    |> Ecto.Changeset.change
+    |> Ecto.Changeset.put_assoc(:admin_branches, branches)
+  end
+
   def pending_approval?(datasheet) do
     datasheet.status == "at_start"
   end
@@ -75,9 +82,9 @@ defmodule Registro.Datasheet do
     !Enum.empty?(datasheet.admin_branches)
   end
 
-  def is_admin_of?(datasheet, %Branch{ id: branch_id }) do
-    is_admin_of?(datasheet, branch_id)
-  end
+  def is_admin_of?(datasheet, %Branch{ id: branch_id }),
+    do: is_admin_of?(datasheet, branch_id)
+
   def is_admin_of?(datasheet, branch_id) do
     # load association if it hasn't been already loaded
     datasheet = Registro.Repo.preload(datasheet, :admin_branches)

--- a/web/models/datasheet.ex
+++ b/web/models/datasheet.ex
@@ -44,7 +44,7 @@ defmodule Registro.Datasheet do
       "at_start" -> "Pendiente"
       "approved" -> "Aprobado"
       "rejected" -> "Rechazado"
-      _ -> ""
+      nil        -> ""
     end
   end
 

--- a/web/models/invitation.ex
+++ b/web/models/invitation.ex
@@ -26,6 +26,15 @@ defmodule Registro.Invitation do
     |> validate_format(:email, ~r/@/)
   end
 
+  def generate_token(changeset) do
+    token = Coherence.ControllerHelpers.random_string(48)
+    put_change(changeset, :token, token)
+  end
+
+  def accept_url(invitation) do
+    Registro.Router.Helpers.invitation_url(Registro.Endpoint, :edit, invitation.token)
+  end
+
   def count do
     Registro.Repo.aggregate __MODULE__, :count, :id
   end

--- a/web/models/role.ex
+++ b/web/models/role.ex
@@ -1,13 +1,5 @@
 defmodule Registro.Role do
 
-  def is_valid?(role) do
-    Enum.member?(["volunteer", "associate"], role)
-  end
-
-  def is_super_admin?(role) do
-    role == "super_admin"
-  end
-
   def label(role) do
     case role do
       "super_admin" -> "Administrador de Sede Central"

--- a/web/models/role.ex
+++ b/web/models/role.ex
@@ -8,7 +8,7 @@ defmodule Registro.Role do
   end
 
   def all do
-    %{label("associate") => "associate",
-      label("volunteer") => "volunteer"}
+    ["associate", "volunteer"]
   end
+
 end

--- a/web/models/role.ex
+++ b/web/models/role.ex
@@ -1,4 +1,13 @@
 defmodule Registro.Role do
+
+  def is_valid?(role) do
+    Enum.member?(["volunteer", "associate"], role)
+  end
+
+  def is_super_admin?(role) do
+    role == "super_admin"
+  end
+
   def label(role) do
     case role do
       "super_admin" -> "Administrador de Sede Central"
@@ -6,18 +15,6 @@ defmodule Registro.Role do
       "volunteer" -> "Voluntario"
       "associate" -> "Asociado"
     end
-  end
-
-  def is_admin?(role) do
-    case role do
-      "super_admin" -> true
-      "branch_admin" -> true
-      _ -> false
-    end
-  end
-
-  def is_super_admin?(role) do
-    role == "super_admin"
   end
 
   def all do

--- a/web/models/role.ex
+++ b/web/models/role.ex
@@ -2,17 +2,13 @@ defmodule Registro.Role do
 
   def label(role) do
     case role do
-      "super_admin" -> "Administrador de Sede Central"
-      "branch_admin" -> "Administrador de Filial"
       "volunteer" -> "Voluntario"
       "associate" -> "Asociado"
     end
   end
 
   def all do
-    %{label("super_admin") => "super_admin",
-      label("branch_admin") => "branch_admin",
-      label("associate") => "associate",
+    %{label("associate") => "associate",
       label("volunteer") => "volunteer"}
   end
 end

--- a/web/plugs/authorization.ex
+++ b/web/plugs/authorization.ex
@@ -35,14 +35,7 @@ defmodule Registro.Authorization do
 
   def call(conn, opts) do
     current_user = conn.assigns[:current_user]
-
-    result = case opts[:check_role] do
-               nil ->
-                 opts[:check].(conn, current_user)
-               check_fn ->
-                 check_fn.(current_user.datasheet.role)
-             end
-
+    result = opts[:check].(conn, current_user)
 
     case result do
       true ->

--- a/web/plugs/authorization.ex
+++ b/web/plugs/authorization.ex
@@ -4,22 +4,17 @@ defmodule Registro.Authorization do
   as well as a conveniente plug for hooking authorization tests into
   controller actions.
 
-  The plug can be check functions that return one of the following:
+  The plug is configured with check functions that receive the connection and
+  the current user and return one of the following:
+
     - true, which means the request is authorized
     - {true, abilities}, which means the request is authorized and
       the user is allowed the specified abilities on the accessed resource
     - any other result means the request is not authorized
 
-  In the simplest case, a check function receives only the role of the current
-  user. Example:
+  Example usage:
   ```
-  plug Registro.Authorization, check_role: &Role.is_super_admin?/1
-  ```
-
-  If more information is needed, use `check` instead of `check_role` to supply a
-  function that received the current user and the request params. Example:
-  ```
-  plug Registro.Authorization, check: &complex_check/2
+  plug Registro.Authorization, check: &MyController.authorize_request/2
   ```
 
   To handle authorization errors without using the plug, use the

--- a/web/static/css/_listings.scss
+++ b/web/static/css/_listings.scss
@@ -20,8 +20,4 @@
   &.clickable tbody tr {
     cursor: pointer;
   }
-  .autocomplete-content {
-    position: absolute;
-    width: 90%;
-  }
 }

--- a/web/static/css/app.scss
+++ b/web/static/css/app.scss
@@ -71,6 +71,12 @@ h3 {
   font-weight: 700;
 }
 
+.autocomplete-content {
+  // make autocomplete appear as floating over the rest of the content
+  position: absolute;
+  width: 90%;
+}
+
 @import "_nav";
 @import "_landing";
 @import "_edit_forms";

--- a/web/static/js/branches.js
+++ b/web/static/js/branches.js
@@ -1,5 +1,40 @@
 import { Listings } from "./listings";
 
+var initAdminSelector = () => {
+  var encodeChips = (chips) => {
+    return chips.map(c => c.tag).join("|")
+  }
+
+  var syncChips = (e, chip) => {
+    var data = chipContainer.material_chip('data')
+    var encodedData = encodeChips(data)
+
+    formInput.val(encodedData)
+  }
+
+  if (!branchAdmins) {
+    throw "Expected global 'branchAdmins' variable to initialize admins selector"
+  }
+
+  var initialData = branchAdmins.map(email => { return { tag: email }})
+  var chipContainer = $('.admin-chips')
+  var formInput = $("input[name='admin_emails']")
+
+  if (!chipContainer.length || !formInput.length) {
+    throw "Invalid markup for chip container"
+  }
+
+  chipContainer.material_chip({
+    placeholder: ' +Email',
+    data: initialData
+  });
+
+  chipContainer.on('chip.add', syncChips);
+  chipContainer.on('chip.delete', syncChips);
+
+  syncChips()
+}
+
 export var Branches = {
   init: function() {
     $("#branches").each(() =>
@@ -12,4 +47,9 @@ export var Branches = {
           document.location.href = $(e.target).closest("tr").data("href")
         }
       })
-    )}};
+   )
+
+   $("#branch-details").each(() => {
+     initAdminSelector()
+   });
+  }};

--- a/web/templates/branches/form.html.eex
+++ b/web/templates/branches/form.html.eex
@@ -18,8 +18,7 @@
   <div class="section">
     <h3>Administradores</h3>
     <script>
-     <% admin_emails = @changeset |> Ecto.Changeset.get_field(:admins) |> Enum.map(&(&1.user.email)) %>
-     var branchAdmins = <%= raw Poison.encode!(admin_emails) %>;
+     var branchAdmins = <%= raw Poison.encode!(@admin_emails) %>;
     </script>
     <input name="admin_emails" type="hidden" value="admin1@instedd.org|admin2@instedd.org"/>
     <div class="input-field">

--- a/web/templates/branches/form.html.eex
+++ b/web/templates/branches/form.html.eex
@@ -15,5 +15,17 @@
     </div>
   </div>
 
+  <div class="section">
+    <h3>Administradores</h3>
+    <script>
+     <% admin_emails = @changeset |> Ecto.Changeset.get_field(:admins) |> Enum.map(&(&1.user.email)) %>
+     var branchAdmins = <%= raw Poison.encode!(admin_emails) %>;
+    </script>
+    <input name="admin_emails" type="hidden" value="admin1@instedd.org|admin2@instedd.org"/>
+    <div class="input-field">
+      <div class="admin-chips"></div>
+    </div>
+  </div>
+
   <%= submit "Actualizar", class: "btn btn-large btn-primary" %>
 <% end %>

--- a/web/templates/branches/show.html.eex
+++ b/web/templates/branches/show.html.eex
@@ -5,6 +5,6 @@
     </div>
   </div>
   <div class="content-main">
-    <%= render "form.html", conn: @conn, changeset: @changeset, action: branches_path(@conn, :update, @branch) %>
+    <%= render "form.html", conn: @conn, changeset: @changeset, admin_emails: @admin_emails, action: branches_path(@conn, :update, @branch) %>
   </div>
 </div>

--- a/web/templates/coherence/email/invitation.html.eex
+++ b/web/templates/coherence/email/invitation.html.eex
@@ -1,5 +1,4 @@
 <div>
-  <p>Hello <%= @name %>!<p>
   <p>
     You have been invited to create an Account. Use the link below to create
     an account.

--- a/web/templates/coherence/invitation/edit.html.eex
+++ b/web/templates/coherence/invitation/edit.html.eex
@@ -12,7 +12,7 @@
 
     <div class="input-field">
       <%= required_label f, :name, "Nombre", class: "control-label" %>
-      <%= text_input f, :name, class: "form-control", required: "" %>
+      <%= text_input f, :name, class: "form-control", required: "", autofocus: "" %>
       <%= error_tag f, :name %>
     </div>
 

--- a/web/templates/coherence/invitation/new.html.eex
+++ b/web/templates/coherence/invitation/new.html.eex
@@ -27,7 +27,7 @@
     <%= inputs_for f, :datasheet, fn fd -> %>
       <% datasheet = @conn.assigns[:current_user].datasheet %>
 
-      <%= if Registro.Role.is_super_admin?(datasheet.role) do %>
+      <%= if datasheet.is_super_admin do %>
         <div class="row">
           <div class="col s12">
             <%= select fd, :branch_id, @conn.assigns[:branches], [class: "form-control", required: ""] %>

--- a/web/templates/layout/_nav.html.eex
+++ b/web/templates/layout/_nav.html.eex
@@ -1,9 +1,18 @@
+<% datasheet = @conn.assigns[:current_user].datasheet %>
+
 <%= menu_item(@conn, users_path(@conn, :profile), "Perfil") %>
-<%= if Registro.Datasheet.is_admin?(@conn.assigns[:current_user].datasheet) do %>
+<%= if Registro.Datasheet.is_admin?(datasheet) do %>
   <%= menu_item(@conn, users_path(@conn, :index), "Usuarios") %>
-<% end %>
-<%= if @conn.assigns[:current_user].datasheet.is_super_admin do %>
-  <%= menu_item(@conn, branches_path(@conn, :index), "Filiales") %>
+
+  <%= if datasheet.is_super_admin do %>
+    <%= menu_item(@conn, branches_path(@conn, :index), "Filiales") %>
+  <% else %>
+    <%= if length(datasheet.admin_branches) == 1 do %>
+      <%= menu_item(@conn, branches_path(@conn, :show, hd(datasheet.admin_branches)), "Mi filial") %>
+    <% else %>
+      <%= menu_item(@conn, branches_path(@conn, :index), "Mis filiales") %>
+    <% end %>
+  <% end %>
 <% end %>
 <li>
   <%= link "Salir", to: session_path(@conn, :delete), method: :delete %>

--- a/web/templates/layout/_nav.html.eex
+++ b/web/templates/layout/_nav.html.eex
@@ -1,8 +1,8 @@
 <%= menu_item(@conn, users_path(@conn, :profile), "Perfil") %>
-<%= if Registro.Role.is_admin?(@conn.assigns[:current_user].datasheet.role) do %>
+<%= if Registro.Datasheet.is_admin?(@conn.assigns[:current_user].datasheet) do %>
   <%= menu_item(@conn, users_path(@conn, :index), "Usuarios") %>
 <% end %>
-<%= if Registro.Role.is_super_admin?(@conn.assigns[:current_user].datasheet.role) do %>
+<%= if @conn.assigns[:current_user].datasheet.is_super_admin do %>
   <%= menu_item(@conn, branches_path(@conn, :index), "Filiales") %>
 <% end %>
 <li>

--- a/web/templates/users/index.html.eex
+++ b/web/templates/users/index.html.eex
@@ -7,8 +7,6 @@
         <option value="">Todos</option>
         <%= role_option("volunteer") %>
         <%= role_option("associate") %>
-        <%= role_option("branch_admin") %>
-        <%= role_option("super_admin") %>
       </select>
     </div>
     <div class="input-field col s3">
@@ -20,7 +18,7 @@
         <option value="rejected"><%= Registro.Datasheet.status_label("rejected") %></option>
       </select>
     </div>
-    <%= if @conn.assigns[:current_user].datasheet.role == "super_admin" do %>
+    <%= if Coherence.current_user(@conn).datasheet.is_super_admin do %>
     <div class="input-field col s3">
       <input type="text" id="branch" class="autocomplete">
       <label for="autocomplete-input">Filial</label>

--- a/web/templates/users/listing.html.eex
+++ b/web/templates/users/listing.html.eex
@@ -19,7 +19,7 @@
             <td><%= u.datasheet.name %></td>
             <td><%= u.email %></td>
             <td></td>
-            <td><%= Registro.Role.label(u.datasheet.role) %></td>
+            <td><%= Registro.Datasheet.role_label(u.datasheet) %></td>
             <td><%= Registro.Datasheet.status_label(u.datasheet.status) %></td>
             <%= if @conn.assigns[:current_user].datasheet.role == "super_admin" do %>
             <td><%= branch_label(u) %></td>

--- a/web/templates/users/show.html.eex
+++ b/web/templates/users/show.html.eex
@@ -36,7 +36,7 @@
               </div>
             </div>
 
-            <div class="colaboration">
+            <div class="section">
               <h3>Colaboración en filial</h3>
               <div class="row">
                 <div class="input-field col s6">
@@ -58,6 +58,10 @@
                 </div>
 
                 <%= if pending_approval do %>
+                  <%#
+                  display the role selected when registering, without allowing changes.
+                  this field can be modified later by an administrator, once the user is approved.
+                  %>
                   <div class="input-field col s3">
                     <%= label fd, :role, "Rol", class: "control-label" %>
                     <%= tag(:input,
@@ -66,6 +70,10 @@
                             ) %>
                     <%= hidden_input fd, :role, class: "form-control", disabled: "" %>
                   </div>
+                  <%#
+                  if pending approval, the status will be set depending on which
+                  button is pressed. (see form actions below).
+                  %>
                   <div class="input-field col s3">
                     <%= label fd, :status, "Estado", class: "control-label" %>
                     <%= tag(:input,
@@ -79,13 +87,23 @@
                     <%= role_selector("user[datasheet][role]", datasheet.role) %>
                     <%= error_tag fd, :role %>
                   </div>
-                  <div class="input-field col s3">
-                    <%= label fd, :status, "Estado", class: "control-label" %>
-                    <%= tag(:input,
-                            class: "form-control", name: "", type: "text", disabled: "",
-                            value: Registro.Datasheet.status_label(@user.datasheet.status),
-                            ) %>
-                  </div>
+                    <%= if @user.datasheet.status do %>
+                      <%#
+                      display the user status without allowing changes.
+
+                      if a user doesn't have status then any change to {branch_id, role}
+                      will automatically mark the status as "approved", so the user is not
+                      required to select the status when marking a user as a colaborator
+                      of a branch.
+                      %>
+                      <div class="input-field col s3">
+                        <%= label fd, :status, "Estado", class: "control-label" %>
+                        <%= tag(:input,
+                                class: "form-control", name: "", type: "text", disabled: "",
+                                value: Registro.Datasheet.status_label(@user.datasheet.status),
+                                ) %>
+                      </div>
+                    <%= end %>
                 <% end %>
               </div>
             </div>

--- a/web/templates/users/show.html.eex
+++ b/web/templates/users/show.html.eex
@@ -74,7 +74,7 @@
               <% else %>
                 <div class="input-field col s3">
                   <%= label fd, :role, "Rol", class: "control-label active" %>
-                  <%= select fd, :role, @roles, class: "form-control", required: "" %>
+                  <%= role_selector("user[datasheet][role]", datasheet.role) %>
                   <%= error_tag fd, :role %>
                 </div>
                 <div class="input-field col s3">

--- a/web/templates/users/show.html.eex
+++ b/web/templates/users/show.html.eex
@@ -38,14 +38,21 @@
 
             <div class="row">
               <div class="input-field col s6">
-                <label class="control-label active" for="user_datasheet_branch_name">Filial</label>
-                <%= tag(:input,
-                  type: "text",
-                  id: "user_datasheet_branch_name",
-                  name: "branch_name",
-                  class: "autocomplete form-control",
-                  value: @branch_name) %>
-                <%= error_tag fd, :branch_name %>
+                <label class="control-label" for="user_datasheet_branch_name">Filial</label>
+                <%= if current_user.datasheet.is_super_admin do %>
+                  <%= tag(:input,
+                    type: "text",
+                    id: "user_datasheet_branch_name",
+                    name: "branch_name",
+                    class: "autocomplete form-control",
+                    value: @branch_name) %>
+                  <%= error_tag fd, :branch_name %>
+                <% else %>
+                  <%= tag(:input,
+                          class: "form-control", name: "", type: "text", disabled: "",
+                          value: @branch_name
+                          ) %>
+                <% end %>
               </div>
 
               <%= if pending_approval do %>

--- a/web/templates/users/show.html.eex
+++ b/web/templates/users/show.html.eex
@@ -36,55 +36,58 @@
               </div>
             </div>
 
-            <div class="row">
-              <div class="input-field col s6">
-                <label class="control-label" for="user_datasheet_branch_name">Filial</label>
-                <%= if current_user.datasheet.is_super_admin do %>
-                  <%= tag(:input,
-                    type: "text",
-                    id: "user_datasheet_branch_name",
-                    name: "branch_name",
-                    class: "autocomplete form-control",
-                    value: @branch_name) %>
-                  <%= error_tag fd, :branch_name %>
+            <div class="colaboration">
+              <h3>Colaboración en filial</h3>
+              <div class="row">
+                <div class="input-field col s6">
+                  <label class="control-label" for="user_datasheet_branch_name">Filial</label>
+                  <%= if current_user.datasheet.is_super_admin do %>
+                    <%= tag(:input,
+                      type: "text",
+                      id: "user_datasheet_branch_name",
+                      name: "branch_name",
+                      class: "autocomplete form-control",
+                      value: @branch_name) %>
+                    <%= error_tag fd, :branch_name %>
+                  <% else %>
+                    <%= tag(:input,
+                            class: "form-control", name: "", type: "text", disabled: "",
+                            value: @branch_name
+                            ) %>
+                  <% end %>
+                </div>
+
+                <%= if pending_approval do %>
+                  <div class="input-field col s3">
+                    <%= label fd, :role, "Rol", class: "control-label" %>
+                    <%= tag(:input,
+                            class: "form-control", name: "", type: "text", disabled: "",
+                            value: "#{Registro.Role.label(@user.datasheet.role)}",
+                            ) %>
+                    <%= hidden_input fd, :role, class: "form-control", disabled: "" %>
+                  </div>
+                  <div class="input-field col s3">
+                    <%= label fd, :status, "Estado", class: "control-label" %>
+                    <%= tag(:input,
+                            class: "form-control", name: "", type: "text", disabled: "",
+                            value: "Pendiente",
+                            ) %>
+                  </div>
                 <% else %>
-                  <%= tag(:input,
-                          class: "form-control", name: "", type: "text", disabled: "",
-                          value: @branch_name
-                          ) %>
+                  <div class="input-field col s3">
+                    <%= label fd, :role, "Rol", class: "control-label active" %>
+                    <%= role_selector("user[datasheet][role]", datasheet.role) %>
+                    <%= error_tag fd, :role %>
+                  </div>
+                  <div class="input-field col s3">
+                    <%= label fd, :status, "Estado", class: "control-label" %>
+                    <%= tag(:input,
+                            class: "form-control", name: "", type: "text", disabled: "",
+                            value: Registro.Datasheet.status_label(@user.datasheet.status),
+                            ) %>
+                  </div>
                 <% end %>
               </div>
-
-              <%= if pending_approval do %>
-                <div class="input-field col s3">
-                  <%= label fd, :role, "Rol", class: "control-label" %>
-                  <%= tag(:input,
-                          class: "form-control", name: "", type: "text", disabled: "",
-                          value: "#{Registro.Role.label(@user.datasheet.role)}",
-                          ) %>
-                  <%= hidden_input fd, :role, class: "form-control", disabled: "" %>
-                </div>
-                <div class="input-field col s3">
-                  <%= label fd, :status, "Estado", class: "control-label" %>
-                  <%= tag(:input,
-                          class: "form-control", name: "", type: "text", disabled: "",
-                          value: "Pendiente",
-                          ) %>
-                </div>
-              <% else %>
-                <div class="input-field col s3">
-                  <%= label fd, :role, "Rol", class: "control-label active" %>
-                  <%= role_selector("user[datasheet][role]", datasheet.role) %>
-                  <%= error_tag fd, :role %>
-                </div>
-                <div class="input-field col s3">
-                  <%= label fd, :status, "Estado", class: "control-label" %>
-                  <%= tag(:input,
-                          class: "form-control", name: "", type: "text", disabled: "",
-                          value: Registro.Datasheet.status_label(@user.datasheet.status),
-                          ) %>
-                </div>
-              <% end %>
             </div>
           <% end %>
 

--- a/web/templates/users/show.html.eex
+++ b/web/templates/users/show.html.eex
@@ -107,6 +107,20 @@
                 <% end %>
               </div>
             </div>
+
+            <%= if current_user.datasheet.is_super_admin do %>
+              <div class="section">
+                <h3>Permisos de administración</h3>
+                <div class="row">
+                  <div class="input_field col s12">
+                    <%= checkbox fd, :is_super_admin, class: "form-control" %>
+                    <%= label fd, :is_super_admin, "Otorgar a este usuario permisos de Super Admin para todo el sistema", class: "control-label" %>
+                  </div>
+                </div>
+              </div>
+            <% else %>
+              <%= hidden_input fd, :is_super_admin, disabled: "" %>
+            <% end %>
           <% end %>
 
           <div class="form-group actions">

--- a/web/templates/users/show.html.eex
+++ b/web/templates/users/show.html.eex
@@ -1,3 +1,4 @@
+<% current_user = Coherence.current_user(@conn) %>
 <% datasheet = @changeset.data.datasheet %>
 <% pending_approval = Registro.Datasheet.pending_approval?(datasheet) %>
 
@@ -36,36 +37,48 @@
             </div>
 
             <div class="row">
-              <div class="input-field col s12">
+              <div class="input-field col s6">
                 <label class="control-label active" for="user_datasheet_branch_name">Filial</label>
                 <%= tag(:input,
                   type: "text",
                   id: "user_datasheet_branch_name",
-                  name: "user[datasheet][branch_name]",
+                  name: "branch_name",
                   class: "autocomplete form-control",
                   value: @branch_name) %>
                 <%= error_tag fd, :branch_name %>
               </div>
-            </div>
 
-            <div class="row">
-            <%= if pending_approval do %>
-              <div class="input-field col s12">
-                <%= label fd, :role, "Rol", class: "control-label active" %>
-                <%= tag(:input,
-                        class: "form-control", name: "", type: "text", disabled: "",
-                        value: "#{Registro.Role.label(@user.datasheet.role)} (pendiente de aprobación)",
-                        ) %>
-                <%= hidden_input fd, :role, class: "form-control", disabled: "" %>
-              </div>
-            <% else %>
-                <div class="input-field col s12">
+              <%= if pending_approval do %>
+                <div class="input-field col s3">
+                  <%= label fd, :role, "Rol", class: "control-label" %>
+                  <%= tag(:input,
+                          class: "form-control", name: "", type: "text", disabled: "",
+                          value: "#{Registro.Role.label(@user.datasheet.role)}",
+                          ) %>
+                  <%= hidden_input fd, :role, class: "form-control", disabled: "" %>
+                </div>
+                <div class="input-field col s3">
+                  <%= label fd, :status, "Estado", class: "control-label" %>
+                  <%= tag(:input,
+                          class: "form-control", name: "", type: "text", disabled: "",
+                          value: "Pendiente",
+                          ) %>
+                </div>
+              <% else %>
+                <div class="input-field col s3">
                   <%= label fd, :role, "Rol", class: "control-label active" %>
                   <%= select fd, :role, @roles, class: "form-control", required: "" %>
                   <%= error_tag fd, :role %>
                 </div>
-            <% end %>
-          </div>
+                <div class="input-field col s3">
+                  <%= label fd, :status, "Estado", class: "control-label" %>
+                  <%= tag(:input,
+                          class: "form-control", name: "", type: "text", disabled: "",
+                          value: Registro.Datasheet.status_label(@user.datasheet.status),
+                          ) %>
+                </div>
+              <% end %>
+            </div>
           <% end %>
 
           <div class="form-group actions">

--- a/web/views/users_view.ex
+++ b/web/views/users_view.ex
@@ -15,4 +15,20 @@ defmodule Registro.UsersView do
       Registro.Role.label(role)
     end
   end
+
+  def role_selector(field_name, current_role) do
+    content_tag(:select, name: field_name, class: "form-control") do
+      prompt_option = content_tag(:option, "Seleccionar", option_attributes(is_nil(current_role), value: "", disabled: ""))
+
+      role_options = Registro.Role.all
+                   |> Enum.map(fn(role) ->
+                                 content_tag(:option, Registro.Role.label(role), option_attributes(current_role == role, value: role))
+                               end)
+
+      [prompt_option | role_options]
+    end
+  end
+
+  defp option_attributes(true, attrs), do: [{:selected, ""} | attrs]
+  defp option_attributes(false, attrs), do: attrs
 end


### PR DESCRIPTION
- A user can now be super_admin or branch_admin while being a colaborator in a branch at the same time
- Branch admins can only list volunteers of their managed branches, but not other branch admins.
- Super admins can grant/revoke super_admin privileges to other users
- Branch admins can add/invite other users as branch admins

Fixes #11 #21 #23